### PR TITLE
Add Optimade Querier and replace current OQMD through optimade

### DIFF
--- a/Xerus/queriers/multiquery.py
+++ b/Xerus/queriers/multiquery.py
@@ -132,11 +132,11 @@ def multiquery(element_list: List[str], max_num_elem: int,  resync:bool = False)
     AFLOWQuery(element_list, outfolder=aflow_path).query()
     td.append(aflow_path)
 
-    # OQMD Query
-    print("Querying OQMD...")
-    oqmd = OQMDQuery(element_list=element_list, dumpfolder=oqmd_path)
-    oqmd.query()
-    td.append(oqmd_path)
+    # # OQMD Query
+    # print("Querying OQMD...")
+    # oqmd = OQMDQuery(element_list=element_list, dumpfolder=oqmd_path)
+    # oqmd.query()
+    # td.append(oqmd_path)
     
 
     # TODO: Evaluate on how to implement each querier through optimade via the generic OptimadeQuery interface
@@ -154,11 +154,15 @@ def multiquery(element_list: List[str], max_num_elem: int,  resync:bool = False)
     #     elements=element_list,
     #     folder_path=Path("optimade")
     # )
-    # oqmd_optimade = OptimadeQuery(
-    #     base_url="https://oqmd.org/optimade/v1/",
-    #     elements=element_list,
-    #     folder_path=Path("optimade")
-    # )
+    print(f"Querying OQMD through OPTIMADE....")
+    oqmd_optimade = OptimadeQuery(
+        base_url="https://oqmd.org/optimade/v1",
+        elements=element_list,
+        folder_path=Path(oqmd_path),
+        extra_filters={"_oqmd_stability": "<0.05"}
+    )
+    oqmd_optimade.query()
+    td.append(oqmd_path)
 
     # td.append(Path("optimade"))
 

--- a/Xerus/queriers/optimade.py
+++ b/Xerus/queriers/optimade.py
@@ -8,8 +8,6 @@ import sys
 from pathlib import Path
 from typing import List, Union
 
-from django.forms import ValidationError
-
 project_path = str(Path(os.path.dirname(os.path.realpath(__file__))).parent) + os.sep # so convoluted..
 if project_path not in sys.path:
     sys.path.append(project_path)
@@ -119,7 +117,7 @@ class OptimadeQuery:
                     print(f"Saving {cifname}... to {self.folder_path}/{cifname}...")
                     # Save cif to path
                     pymatgen_structure.to(fmt="cif", filename=self.folder_path.joinpath(cifname), symprec=self.symprec)
-                except ValidationError:
+                except ValueError:
                         print(f'Failed to convert {entry["id"]} to pymatgen structure..')
                 
         if next_query_url:


### PR DESCRIPTION
This pull request is a working in progress for  #2 

It implements the following:
- Implement the OptimadeQuery structure that allows to query any optimade structure provider
- Replaces the current OQMD Querier (using their own API) to an optimade querier
- Partially supports COD through Optimade. Few issues still are present (how to handle large crystal structure files?)
- Allows to provide provider based special filters as a dict (ie. {"_oqmd_stability": "<0.01"})

Current  issues
Currently there is an inconsistency between the return schema of OQMD/COD regarding to next_query_url: One returns directly the URL (OQMD), while COD is returning a dict.

