### PR TITLE
Added support for multiple uses querying at same time (experimental..)

### DIFF
--- a/Xerus/__init__.py
+++ b/Xerus/__init__.py
@@ -21,10 +21,8 @@
 from __future__ import annotations
 
 import os
-import sys
 from multiprocessing import Pool
-from pathlib import Path
-from typing import Any, List, Tuple, Union
+from typing import Any, List, Union
 
 import numpy as np
 import pandas as pd
@@ -42,10 +40,10 @@ from Xerus.similarity.pattern_removal import (combine_pos,
                                               run_correlation_analysis,
                                               run_correlation_analysis_riet)
 from Xerus.similarity.visualization import make_plot_all, make_plot_step
-from Xerus.utils.cifutils import make_system, make_system_types
+from Xerus.utils.cifutils import make_system
 from Xerus.utils.preprocessing import remove_baseline, standarize_intensity
-from Xerus.utils.tools import (blockPrinting, create_folder, group_data,
-                               load_json, make_offset, normalize_formula)
+from Xerus.utils.tools import (create_folder, group_data, load_json,
+                               make_offset, normalize_formula)
 from Xerus.utils.tools import plotly_add as to_add
 from Xerus.utils.tools import save_json
 
@@ -227,6 +225,7 @@ class XRay:
             outfolder=self.working_folder,
             maxn=self.maxsys,
             max_oxy=self.max_oxy,
+            name = self.name
         )
         self.cif_info = cif_meta
         if ignore_provider is not None:

--- a/Xerus/queriers/tcif.py
+++ b/Xerus/queriers/tcif.py
@@ -42,22 +42,15 @@ import os
 import sys
 from pathlib import Path
 
-from Xerus.engine.gsas2riet import run_gsas, simulate_pattern
+from tqdm import tqdm
+from Xerus.engine.gsas2riet import run_gsas
 from Xerus.settings.settings import INSTR_PARAMS, TEST_XRD
+from Xerus.utils.cifutils import get_ciflist
 
 instr_params = INSTR_PARAMS
 powder_data = TEST_XRD
 abs_path = Path(__file__).parent
-cif_folder = os.path.join(abs_path, "queried_cifs")
-cif_name = "cif.json"
-datapath = os.path.join(cif_folder,cif_name)
-from tqdm import tqdm
-from Xerus.utils.cifutils import get_ciflist
-
-if not os.path.exists(datapath):
-    get_ciflist(str(cif_folder) + os.sep, "r", True)
-with open(datapath, "r") as fp:
-    data = json.load(fp)
+# cif_folder = os.path.join(abs_path, "queried_cifs")
 
 def load_json(path):
     with open(path, "r") as fp:
@@ -66,7 +59,7 @@ def load_json(path):
 def check_extension(file, allowed=(".json", ".cif", ".ipynb_checkpoints")):
     return any([file.endswith(extension) for extension in allowed])
 
-def save_json(dict, filename=cif_name, folder=cif_folder):
+def save_json(dict, filename, folder):
     """
 
     :param dict:
@@ -78,6 +71,16 @@ def save_json(dict, filename=cif_name, folder=cif_folder):
         json.dump(dict, fp)
 
 if __name__ == "__main__":
+    # Get cif folder from command line
+    cif_folder = sys.argv[1]
+    cif_name = "cif.json"
+    datapath = os.path.join(cif_folder,cif_name)
+
+    if not os.path.exists(datapath):
+        get_ciflist(str(cif_folder) + os.sep, "r", True)
+    with open(datapath, "r") as fp:
+        data = json.load(fp)
+
 
     for i, entry in tqdm(enumerate(data)):
         filename = entry['filename']
@@ -120,7 +123,7 @@ if __name__ == "__main__":
     #             data[i]['gsas_status']['status'] = 1
     #             data[i]['gsas_status']['tested'] = True
     #             data[i]['ran'] = True
-    save_json(data)
+    save_json(data, "cif.json", cif_folder)
     ## clean up .lst, .gpx, .bak
     files = os.listdir(cif_folder)
     for file in files:


### PR DESCRIPTION
This PR does the following:

1. Change the querying to use the folder name in the dataset-name_chemical-space_provider and the final folder as dataset-name_cifs
2. Allows tcif.py to accept a specific folder name
3. Changes the MongoIndex 'id' (which is the one of a given provider) to be unique 
4. If the collection does not exist, create it and do the above
5. Changes Xray, localdb, multiquery to accept 'name' as paramater (used when creating dump folders of CIFs)

> WARNING: For old databases, it might be needed to manually set the 'id' field of mongo as unique (this should be possible right?)

(Possibly) Closes #22 