### PR TITLE
Fix missing `libgfortran4` dependency in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,11 @@ concurrency:
 
 jobs:
   pytest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        # Must be added for the conda/mamba shell integration to work
+        shell: bash -el {0}
 
     strategy:
       fail-fast: false
@@ -28,22 +32,29 @@ jobs:
         image: mongo:4
         ports:
         - 27017:27017
-    
+
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-
     - name: Install OS deps
       run: |
-        sudo apt install -y subversion libgfortran4
+        sudo apt install -y subversion
 
-    - name: Install Python package and dependencies
+    - name: Setup Conda
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        use-mamba: true
+        mamba-version: "*"
+        activate-environment: test
+        channels: conda-forge,defaults
+        channel-priority: true
+
+    - name: Setup conda environment with dependencies
       run: |
-        python -m pip install --upgrade pip
+        python --version
+        mamba install -c conda-forge libgfortran4
+        pip install --upgrade pip
         pip install -U setuptools wheel
         pip install -e .
 


### PR DESCRIPTION
Closes #42 by installing libgfortran4 from conda-forge in the CI.