### PR TITLE
Add OPTIMADE query to optimade-misc.odbx.science

### DIFF
--- a/Xerus/queriers/multiquery.py
+++ b/Xerus/queriers/multiquery.py
@@ -135,6 +135,17 @@ def multiquery(element_list: List[str], name: str, resync:bool = False) -> None:
     oqmd_optimade.query()
     td.append(oqmd_path)
 
+    odbx_misc_path = os.path.join(abs_path, f"{name}_{query_type}_odbx_misc")
+    print(f"Querying odbx through OPTIMADE")
+    odbx_misc_optimade = OptimadeQuery(
+        base_url="https://optimade-misc.odbx.science/v1",
+        elements=element_list,
+        folder_path=Path(odbx_misc_path),
+        extra_filters={"_odbx_hull_distance": "<0.05"}
+    )
+    odbx_misc_optimade.query()
+    td.append(odbx_misc_path)
+
     test_folder = os.path.join(abs_path,f"{name}_{query_type}_cifs")
     movecifs(dump_folders=td, test_folder=test_folder)
     print("Finished downloading CIFs.")


### PR DESCRIPTION
This PR adds a query to https://optimade-misc.odbx.science, which contains datasets from various materials discovery papers (with lots of as-of-yet undiscovered structures!) and their self-reported stability data.

One thing to maybe worry about (here and elsewhere):

If someone uses a structure from this database, Xerus cannot currently provide the appropriate reference as a) this is just a random database I am personally hosting, b) it does not pull from the OPTIMADE `/references` endpoint which tracks the per-structure citations. There is maybe the same issue with other databases, where the only reference would be the one to the overall database itself, and not the primary source of the data.

One way to fix this (for OPTIMADE) would be to use the OPTIMADE client from optimade-python-tools directly to query a subset of all OPTIMADE databases and then write the bibliographic info into the saved CIF.

Perhaps a note could also be added to the README with something like: 

> If you make use of a match to a specific database entry in your published work, please make sure you hunt down the source citation for both the overall database and the precise entries that were used.