### PR TITLE
Small patch of optimade (workaround)

### DIFF
--- a/Xerus/queriers/optimade.py
+++ b/Xerus/queriers/optimade.py
@@ -11,6 +11,7 @@ import requests
 from Xerus.settings.settings import REQUESTS_TIMEOUT, REQUESTS_HEADER
 
 from optimade.adapters import Structure
+from pymatgen.core import Structure as PymatgenStructure
 
 
 class OptimadeQuery:
@@ -140,7 +141,7 @@ class OptimadeQuery:
                     # Get the suffix from provider and provider id
                     cif_suffix = self.make_suffix(entry=structure.entry.dict(), meta=meta)
                     # Convert the optimade structure into pymatgen format
-                    pymatgen_structure = structure.convert("pymatgen")
+                    pymatgen_structure = PymatgenStructure.from_str(structure.convert("cif"), fmt="cif")
                     # Get the reduced formula
                     formula = pymatgen_structure.composition.reduced_formula
                     # Make the cifname


### PR DESCRIPTION
This is a patch workaround since as of optimade > 1.6.0, the pymatgen adapter from Optimade seems to be broken. 

To avoid issues, we are currently doing Optimade CIF (to cif) adapater and parsing the CIF using pymatgen Structure (from_str, fmt='cif') object itself.


@ml-evs 
I am not sure where I can report this, however since the optimade > 1.6.0, the Pymatgen adapter gives the following error:
```bash
File ~/anaconda3/envs/XerusMin/lib/python3.8/site-packages/optimade/adapters/structures/pymatgen.py:79, in _get_structure(optimade_structure)
     74 """Create pymatgen Structure from OPTIMADE structure"""
     76 attributes = optimade_structure.attributes
     78 return Structure(
---> 79     lattice=Lattice(attributes.lattice_vectors, attributes.dimension_types),
     80     species=_pymatgen_species(
     81         nsites=attributes.nsites,  # type: ignore[arg-type]
     82         species=attributes.species,
     83         species_at_sites=attributes.species_at_sites,  # type: ignore[arg-type]
     84     ),
     85     coords=attributes.cartesian_site_positions,
     86     coords_are_cartesian=True,
     87 )

TypeError: __init__() takes 2 positional arguments but 3 were given
```
When using:
```python
pymatgen_structure = structure.convert("pymatgen")
```
Where:
```python
 structure = Structure(entry)
```
And entry is coming from an optimade query