### PR TITLE
Oxides

### DIFF
--- a/Xerus/__init__.py
+++ b/Xerus/__init__.py
@@ -206,7 +206,8 @@ class XRay:
         self,
         ignore_provider: List[str] = None,
         ignore_comb: List[str] = None,
-        ignore_ids: List[str] = None,
+        ignore_ids: List[str] = None, 
+        ceramic:bool = False,
     ) -> XRay:
         """
         Get cifs from MongoDB and write to working folder.
@@ -227,7 +228,8 @@ class XRay:
             outfolder=self.working_folder,
             maxn=self.maxsys,
             max_oxy=self.max_oxy,
-            name = self.name
+            name = self.name,
+            oxide = ceramic
         )
         self.cif_info = cif_meta
         if ignore_provider is not None:
@@ -557,6 +559,7 @@ class XRay:
             ignore_provider=ignore_provider,
             ignore_comb=ignore_comb,
             ignore_ids=ignore_ids,
+            ceramic = is_ceramic,
         ).simulate_all(n_jobs=n_jobs).calculate_correlations(
             select_cifs=select_cifs, by_sys=systype
         )

--- a/Xerus/__init__.py
+++ b/Xerus/__init__.py
@@ -509,7 +509,7 @@ class XRay:
         plot_all : To export all refinement plots (defaults to False)
         ignore_provider : A list of providers to ignore. Default: ["AFLOW"], due to the large amount of theoretical crystal structures. Can be manually turned on.
         ignore_comb : A list of combinations to ignore. Eg: ["B-O"], would ignore searching for B-O oxide.
-        is_ceramic : make auto-filling of ignore_comb if it is ceramic material
+        is_ceramic : make auto-filling of ignore_comb if it is ceramic material and reduce query list
         ignore_ids: A list of possible unique IDs to ignore. Defaults to None.
         solver: Decide which solver to use. Defaults to box method "box". For residual method use "rietveld"
         group_method: Decides how to try to group similiar crystal structures. Defaults to "system_type".

--- a/Xerus/db/localdb.py
+++ b/Xerus/db/localdb.py
@@ -200,7 +200,7 @@ class LocalDB:
                 self.check_and_download(combination, name = name)
         return self
 
-    def get_cifs_and_write(self, element_list : List[str], name: str, outfolder: str, maxn: int, max_oxy: int = 2) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    def get_cifs_and_write(self, element_list : List[str], name: str, outfolder: str, maxn: int, max_oxy: int = 2, oxide:bool = False) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
         """
 
         Automatically receives a list of elements and make `system_types`.
@@ -236,7 +236,7 @@ class LocalDB:
             os.mkdir(outfolder)  # make folder if nto exist.
         folder_to_write = 'cifs/'
         final_path = os.path.join(outfolder, folder_to_write)
-        queries = make_system_types(element_list, maxn)
+        queries = make_system_types(element_list, maxn, ceramic_mode=oxide)
         self.check_all(queries, name = name)
 
         # check oxygen limit

--- a/Xerus/db/localdb.py
+++ b/Xerus/db/localdb.py
@@ -222,6 +222,8 @@ class LocalDB:
         max_oxy : int
             Maximum oxygen for `system_type`. For example `max_oxy` = 2, will allow up to binary oxides, however in case
             of len(element_list) > 2 and O is one the elements, the `system_type`: "A-B-O" will not be considered.
+        oxide : bool
+            if it is oxide, when ture, only oxide will be in query.
 
         Returns
         -------

--- a/Xerus/utils/cifutils.py
+++ b/Xerus/utils/cifutils.py
@@ -221,10 +221,10 @@ def make_system_types(elements: List[str], size: int = None, ceramic_mode: bool 
     """
     if size is None:
         size = len(elements)
-        if ceramic_mode:
-            return [make_system(standarize(comb)) for comb in make_combinations_oxide(elements, size)]
-        else:
-            return [make_system(standarize(comb)) for comb in make_combinations(elements, size)]
+    if ceramic_mode:
+        return [make_system(standarize(comb)) for comb in make_combinations_oxide(elements, size)]
+    else:
+        return [make_system(standarize(comb)) for comb in make_combinations(elements, size)]
 
 
 def make_system(comp: str) -> str:

--- a/Xerus/utils/cifutils.py
+++ b/Xerus/utils/cifutils.py
@@ -204,7 +204,7 @@ def get_elements(name: str) -> List[str]:
     return Composition(name).chemical_system.split("-")
 
 
-def make_system_types(elements: List[str], size: int = None) -> List[str]:
+def make_system_types(elements: List[str], size: int = None, ceramic_mode: bool = False) -> List[str]:
     """
     Make "system-types" from a list of elements
 
@@ -221,7 +221,10 @@ def make_system_types(elements: List[str], size: int = None) -> List[str]:
     """
     if size is None:
         size = len(elements)
-    return [make_system(standarize(comb)) for comb in make_combinations(elements, size)]
+        if ceramic_mode:
+            return [make_system(standarize(comb)) for comb in make_combinations_oxide(elements, size)]
+        else:
+            return [make_system(standarize(comb)) for comb in make_combinations(elements, size)]
 
 
 def make_system(comp: str) -> str:

--- a/Xerus/utils/cifutils.py
+++ b/Xerus/utils/cifutils.py
@@ -110,7 +110,7 @@ def make_combinations_oxide(element_list: List[str], max_num_elem: int) -> List[
 
     Returns
     -------
-    A list of tuples of each combination. ie:
+    A list of each combination. ie:
     ['Fe','La','Sr','Ba','O'] ->[['O', 'Fe'], ['O', 'La'], ['O', 'Sr'], 
     ['O', 'Ba'], ['O', 'Fe', 'La'], ['O', 'La', 'Sr'], ['O', 'Sr', 'Ba'], 
     ['O', 'Fe', 'La', 'Sr'], ['O', 'La', 'Sr', 'Ba'], ['O', 'Fe', 'La', 'Sr', 'Ba']]

--- a/Xerus/utils/cifutils.py
+++ b/Xerus/utils/cifutils.py
@@ -100,7 +100,7 @@ def make_combinations(element_list: List[str], max_num_elem: int) -> List[Tuple[
 def get_combinations_oxide(iterable, length):
     return [iterable[i:i+length] for i in range(len(iterable) - length + 1)]
 
-def make_combinations_oxides(element_list: List[str], max_num_elem: int) -> List[Tuple[str]]:
+def make_combinations_oxide(element_list: List[str], max_num_elem: int) -> List[Tuple[str]]:
     """
     Function to make a list of elements combinations for oxides
     Parameters

--- a/Xerus/utils/cifutils.py
+++ b/Xerus/utils/cifutils.py
@@ -97,6 +97,36 @@ def make_combinations(element_list: List[str], max_num_elem: int) -> List[Tuple[
     combinations_flat = [item for sublist in comb for item in sublist]
     return combinations_flat
 
+def get_combinations_oxide(iterable, length):
+    return [iterable[i:i+length] for i in range(len(iterable) - length + 1)]
+
+def make_combinations_oxides(element_list: List[str], max_num_elem: int) -> List[Tuple[str]]:
+    """
+    Function to make a list of elements combinations for oxides
+    Parameters
+    ----------
+    element_list : List of elements to be combined
+    max_num_elem : Maximum combination lenght.
+
+    Returns
+    -------
+    A list of tuples of each combination. ie:
+    ['Fe','La','Sr','Ba','O'] ->[['O', 'Fe'], ['O', 'La'], ['O', 'Sr'], 
+    ['O', 'Ba'], ['O', 'Fe', 'La'], ['O', 'La', 'Sr'], ['O', 'Sr', 'Ba'], 
+    ['O', 'Fe', 'La', 'Sr'], ['O', 'La', 'Sr', 'Ba'], ['O', 'Fe', 'La', 'Sr', 'Ba']]
+
+    """
+    specific_element = 'O'
+    # Create a sublist without the specific element
+    sublist = [x for x in element_list if x != specific_element]
+    combinations_oxide = []
+    # Generate combinations of different lengths
+    for length in range(1, max_num_elem):
+        current_combinations = get_combinations_oxide(sublist, length)
+    for combo in current_combinations:
+        combinations_oxide.append([specific_element,] + list(combo))
+    return combinations_oxide
+
 
 def rename_multicif(folder_path: str, provider: str = 'COD') -> None:
     """


### PR DESCRIPTION
In the analyze function, even if we specified is_ceramic = Ture, it will only take care of ignor_com, but non oxide combinations are still listed in query? (i think ) So just made a new function (make_combinations_oxide) in [cifutils.py] that take oxides combinations only; and changed some places that can call the function when is_ceramic = Ture. So only oxides will be considered in query. (i think the implementation here will not influence the other parts, but you can check and modify, since you knows the best of the code) 